### PR TITLE
Fix meal plan parsing and leftover flag

### DIFF
--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -31,7 +31,7 @@ const MealCard: React.FC<MealCardProps> = ({ meal, className = '' }) => {
           {meal.mealType}
         </span>
         <div className="flex items-center space-x-2">
-          {meal.isLeftover && (
+          {meal.leftover && (
             <span className="px-2 py-1 bg-gray-100 text-gray-700 rounded-full text-xs font-medium">
               Leftover
             </span>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -40,12 +40,14 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
         const res = await fetch('http://localhost:8080/api/meal-plans/current');
         let meals: Meal[] = [];
         if (res.ok) {
-          type MealResponse = Omit<Meal, 'isLeftover'> & { leftover: boolean };
-          const data: MealResponse[] = await res.json();
-          meals = data.map((m) => ({
-            ...m,
-            isLeftover: m.leftover,
-          }));
+          type MealPlanResponse = {
+            id: number;
+            startDate: [number, number, number];
+            endDate: [number, number, number];
+            meals: Meal[];
+          };
+          const data: MealPlanResponse = await res.json();
+          meals = data.meals;
         }
 
         setState({

--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -8,7 +8,7 @@ export const mockMeals: Meal[] = [
     description: "Protein-rich quinoa with fresh vegetables, olives, and feta cheese",
     healthBenefits: "High in plant protein and omega-3 fatty acids. Quinoa provides all essential amino acids while olive oil supports heart health. Rich in fiber and antioxidants from colorful vegetables.",
     cookingTime: 25,
-    isLeftover: false,
+    leftover: false,
     ingredients: [
       { name: "Quinoa", quantity: "1", unit: "cup" },
       { name: "Cherry tomatoes", quantity: "200", unit: "g" },
@@ -28,7 +28,7 @@ export const mockMeals: Meal[] = [
     description: "Creamy Greek yogurt topped with raw honey, walnuts, and fresh berries",
     healthBenefits: "Packed with probiotics for digestive health and high-quality protein. Walnuts provide omega-3 fatty acids and vitamin E. Berries offer powerful antioxidants and fiber.",
     cookingTime: 5,
-    isLeftover: false,
+    leftover: false,
     ingredients: [
       { name: "Greek yogurt", quantity: "200", unit: "g" },
       { name: "Raw honey", quantity: "1", unit: "tbsp" },
@@ -45,7 +45,7 @@ export const mockMeals: Meal[] = [
     description: "Fresh sea bass grilled with Mediterranean herbs and seasonal vegetables",
     healthBenefits: "Rich in omega-3 fatty acids and lean protein. Grilled vegetables retain maximum nutrients while herbs provide antioxidants and anti-inflammatory compounds.",
     cookingTime: 35,
-    isLeftover: false,
+    leftover: false,
     ingredients: [
       { name: "Sea bass fillets", quantity: "400", unit: "g" },
       { name: "Zucchini", quantity: "2", unit: "medium" },
@@ -65,7 +65,7 @@ export const mockMeals: Meal[] = [
     description: "Energy-boosting mix of almonds, dried figs, and dark chocolate",
     healthBenefits: "Provides sustained energy from healthy fats and natural sugars. Almonds offer vitamin E and magnesium, while dark chocolate contains flavonoids for heart health.",
     cookingTime: 0,
-    isLeftover: true,
+    leftover: true,
     ingredients: [
       { name: "Raw almonds", quantity: "40", unit: "g" },
       { name: "Dried figs", quantity: "30", unit: "g" },

--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -59,7 +59,7 @@ const MealDetail: React.FC = () => {
               >
                 {meal.mealType}
               </span>
-              {meal.isLeftover && (
+              {meal.leftover && (
                 <span className="px-3 py-1 bg-gray-100 text-gray-700 rounded-full text-sm font-medium border border-gray-200">
                   Leftover
                 </span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,8 @@ export interface Meal {
   description: string;
   healthBenefits: string;
   cookingTime: number;
-  isLeftover: boolean;
+  leftover: boolean;
+  cookDate?: [number, number, number];
   ingredients: Ingredient[];
   recipe: string;
 }


### PR DESCRIPTION
## Summary
- parse `meal-plans/current` response correctly
- switch leftover prop usage from `isLeftover` to `leftover`
- update mock data and Meal type

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883d9c52308832e90fd27fdcbcf7d85