### PR TITLE
Add cooked button to meal detail

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:8080';
+

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { AppState, InventoryItem, Meal, ShoppingListItem } from '../types';
 import { mockInventory } from '../data/mockData';
+import { API_BASE_URL } from '../config';
 
 interface AppContextType extends AppState {
   toggleShoppingItemPurchased: (id: number) => void;
@@ -37,7 +38,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
       setState(prev => ({ ...prev, isLoading: true }));
 
       try {
-        const res = await fetch('http://localhost:8080/api/meal-plans/current');
+        const res = await fetch(`${API_BASE_URL}/api/meal-plans/current`);
         let meals: Meal[] = [];
         if (res.ok) {
           type MealPlanResponse = {
@@ -50,7 +51,7 @@ export const AppProvider: React.FC<AppProviderProps> = ({ children }) => {
           meals = data.meals;
         }
 
-        const shoppingRes = await fetch('http://localhost:8080/api/shopping-lists/current');
+        const shoppingRes = await fetch(`${API_BASE_URL}/api/shopping-lists/current`);
         let shoppingList = [] as ShoppingListItem[];
         if (shoppingRes.ok) {
           type ShoppingListResponse = {

--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -4,6 +4,7 @@ import { Clock } from 'lucide-react';
 import { useAppContext } from '../context/AppContext';
 import Header from '../components/Header';
 import LoadingSpinner from '../components/LoadingSpinner';
+import { API_BASE_URL } from '../config';
 
 const MealDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -40,13 +41,31 @@ const MealDetail: React.FC = () => {
     return colors[mealType as keyof typeof colors];
   };
 
+  const handleCooked = async () => {
+    try {
+      await fetch(`${API_BASE_URL}/api/meals/${meal.id}`, {
+        method: 'PUT'
+      });
+    } catch (err) {
+      console.error('Failed to mark meal as cooked', err);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-50 pb-20 md:pb-8">
       <Header title={meal.name} showBackButton className="bg-green-600 text-white border-green-700">
-        <div className="flex items-center space-x-1 text-green-100">
-          <Clock className="w-4 h-4" />
-          <span className="text-sm font-medium">{meal.cookingTime}m</span>
-        </div>
+        <>
+          <div className="flex items-center space-x-1 text-green-100">
+            <Clock className="w-4 h-4" />
+            <span className="text-sm font-medium">{meal.cookingTime}m</span>
+          </div>
+          <button
+            onClick={handleCooked}
+            className="bg-green-500 text-white px-4 py-2 rounded-lg font-medium hover:bg-green-400 transition-colors"
+          >
+            Cooked!
+          </button>
+        </>
       </Header>
 
       <div className="max-w-md mx-auto md:max-w-4xl">


### PR DESCRIPTION
## Summary
- add green Cooked! button at meal detail header
- call PUT /api/meals/{id} to mark meal as cooked
- centralize API base URL in config and use for meal and shopping fetches

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689714143ee8832e8c2f7d99e1fefffd