### PR TITLE
Fix recipe steps to render as ordered list

### DIFF
--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -129,11 +129,13 @@ const MealDetail: React.FC = () => {
               Recipe
             </h2>
             <div className="prose prose-sm max-w-none">
-              {meal.recipe.split('\n\n').map((step, index) => (
-                <p key={index} className="text-gray-700 leading-relaxed mb-3 last:mb-0">
-                  {step}
-                </p>
-              ))}
+              <ol className="list-decimal pl-4 space-y-2">
+                {meal.recipe.split('\n\n').map((step, index) => (
+                  <li key={index} className="text-gray-700 leading-relaxed">
+                    {step.replace(/^\d+\.\s*/, '')}
+                  </li>
+                ))}
+              </ol>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Render meal recipes as numbered ordered lists rather than paragraphs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68971f8d5870832e8d939953f4cd3aa3