### PR TITLE
style: restore BITE meal tag styling

### DIFF
--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -14,7 +14,8 @@ const MealCard: React.FC<MealCardProps> = ({ meal, className = '' }) => {
       BREAKFAST: 'bg-orange-100 text-orange-800',
       LUNCH: 'bg-green-100 text-green-800',
       DINNER: 'bg-blue-100 text-blue-800',
-      SNACK: 'bg-purple-100 text-purple-800'
+      SNACK: 'bg-purple-100 text-purple-800',
+      BITE: 'bg-yellow-100 text-yellow-800'
     };
     return colors[mealType];
   };

--- a/src/components/MealCard.tsx
+++ b/src/components/MealCard.tsx
@@ -14,8 +14,7 @@ const MealCard: React.FC<MealCardProps> = ({ meal, className = '' }) => {
       BREAKFAST: 'bg-orange-100 text-orange-800',
       LUNCH: 'bg-green-100 text-green-800',
       DINNER: 'bg-blue-100 text-blue-800',
-      SNACK: 'bg-purple-100 text-purple-800',
-      BITE: 'bg-yellow-100 text-yellow-800'
+      BITE: 'bg-purple-100 text-purple-800'
     };
     return colors[mealType];
   };

--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -36,7 +36,8 @@ const MealDetail: React.FC = () => {
       BREAKFAST: 'bg-orange-100 text-orange-800 border-orange-200',
       LUNCH: 'bg-green-100 text-green-800 border-green-200',
       DINNER: 'bg-blue-100 text-blue-800 border-blue-200',
-      SNACK: 'bg-purple-100 text-purple-800 border-purple-200'
+      SNACK: 'bg-purple-100 text-purple-800 border-purple-200',
+      BITE: 'bg-yellow-100 text-yellow-800 border-yellow-200'
     };
     return colors[mealType as keyof typeof colors];
   };

--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -36,8 +36,7 @@ const MealDetail: React.FC = () => {
       BREAKFAST: 'bg-orange-100 text-orange-800 border-orange-200',
       LUNCH: 'bg-green-100 text-green-800 border-green-200',
       DINNER: 'bg-blue-100 text-blue-800 border-blue-200',
-      SNACK: 'bg-purple-100 text-purple-800 border-purple-200',
-      BITE: 'bg-yellow-100 text-yellow-800 border-yellow-200'
+      BITE: 'bg-purple-100 text-purple-800 border-purple-200'
     };
     return colors[mealType as keyof typeof colors];
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface Ingredient {
 export interface Meal {
   id: number;
   name: string;
-  mealType: 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK' | 'BITE';
+  mealType: 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'BITE';
   description: string;
   healthBenefits: string;
   cookingTime: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,7 +6,7 @@ export interface Ingredient {
 export interface Meal {
   id: number;
   name: string;
-  mealType: 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK';
+  mealType: 'BREAKFAST' | 'LUNCH' | 'DINNER' | 'SNACK' | 'BITE';
   description: string;
   healthBenefits: string;
   cookingTime: number;


### PR DESCRIPTION
## Summary
- add BITE meal type to type definitions
- style BITE meal tag with yellow background and border

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689721f4e72c832ea870cee5fd23a518