### PR TITLE
Display ingredient preparation details

### DIFF
--- a/src/pages/MealDetail.tsx
+++ b/src/pages/MealDetail.tsx
@@ -125,10 +125,20 @@ const MealDetail: React.FC = () => {
             </h2>
             <ul className="space-y-3">
               {meal.ingredients.map((ingredient, index) => (
-                <li key={index} className="flex items-center justify-between py-2 border-b border-gray-100 last:border-b-0">
-                  <span className="text-gray-900 font-medium">
-                    {ingredient.name}
-                  </span>
+                <li
+                  key={index}
+                  className="flex items-start justify-between py-2 border-b border-gray-100 last:border-b-0"
+                >
+                  <div className="flex flex-col space-y-0.5">
+                    <span className="text-gray-900 font-medium">
+                      {ingredient.name}
+                    </span>
+                    {ingredient.details && (
+                      <span className="text-sm text-gray-500">
+                        {ingredient.details}
+                      </span>
+                    )}
+                  </div>
                   <span className="text-gray-600 text-sm">
                     {ingredient.grams} g
                   </span>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface Ingredient {
   name: string;
   grams: number;
+  details?: string;
 }
 
 export interface Meal {


### PR DESCRIPTION
## Summary
- show ingredient details below ingredient name on meal page with subtle styling
- extend Ingredient type to include optional `details`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976e4a0d5c832eb36e73673e1f3b3e